### PR TITLE
Update flake.nix to allow proper cross-compiling

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -1,51 +1,157 @@
 {
   inputs = {
-    nixpkgs.url     = "github:NixOS/nixpkgs/nixos-24.11";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.11";
     flake-utils.url = "github:numtide/flake-utils";
   };
 
-  outputs = { self, nixpkgs, flake-utils, ... }:
-    flake-utils.lib.eachDefaultSystem (system:
-      let
-        pkgs = import nixpkgs { inherit system; };
-      in {
-        devShells.default = pkgs.mkShell {
-          buildInputs = [
-            pkgs.go_1_22
-          ];
-        };
+  outputs =
+    {
+      self,
+      nixpkgs,
+      flake-utils,
+      ...
+    }:
+    let
+      supportedSystems = [
+        "x86_64-linux"
+        "aarch64-linux"
+      ];
+      forAllSystems = f: nixpkgs.lib.genAttrs supportedSystems (system: f system);
+      nixpkgsFor = forAllSystems (
+        system:
+        import nixpkgs {
+          inherit system;
+        }
+      );
 
-        packages = rec {
-          dkm = pkgs.buildGoModule {
-            name = "dkm";
-            src = ./.;
-
-            vendorHash = "sha256-9smxGxt+XHXc6KZnGxCQ9SlFGPu7BmsLATV/O4fybFU=";
-
-            buildPhase = "make";
-
-            nativeBuildInputs = [ pkgs.go_1_22 ];
-            buildInputs = [];
-
-            installPhase = ''
-              mkdir -p $out/bin
-              cp dkm $out/bin/
-            '';
-
-            meta = with pkgs.lib; {
-              description = "Doge Key Manager";
-              homepage = "https://github.com/dogeorg/dkm";
-              license = licenses.mit;
-              maintainers = with maintainers; [ dogecoinfoundation ];
-              platforms = platforms.all;
+      buildDkm =
+        {
+          pkgs,
+          targetPkgs ? pkgs,
+          goos ? null,
+          goarch ? null,
+        }:
+        let
+          systemConfig = {
+            "x86_64-linux" = {
+              os = "linux";
+              arch = "amd64";
+            };
+            "aarch64-linux" = {
+              os = "linux";
+              arch = "arm64";
             };
           };
 
-          default = dkm;
+          targetSystem = targetPkgs.stdenv.hostPlatform.system;
+          targetConfig = systemConfig.${targetSystem} or (throw "Unsupported target system: ${targetSystem}");
+
+          finalGoos = if goos != null then goos else targetConfig.os;
+          finalGoarch = if goarch != null then goarch else targetConfig.arch;
+
+          buildGoModuleCross =
+            if pkgs.stdenv.hostPlatform.system != targetPkgs.stdenv.hostPlatform.system then
+              pkgs.buildGoModule
+            else
+              targetPkgs.buildGoModule;
+
+        in
+        buildGoModuleCross {
+          name = "dkm";
+          src = ./.;
+
+          vendorHash = "sha256-9smxGxt+XHXc6KZnGxCQ9SlFGPu7BmsLATV/O4fybFU=";
+
+          nativeBuildInputs = [ pkgs.go_1_22 ];
+          buildInputs = [ ];
+
+          stdenv = targetPkgs.stdenv;
+          CGO_ENABLED = "1";
+          GOOS = finalGoos;
+          GOARCH = finalGoarch;
+          CC = "${targetPkgs.stdenv.cc}/bin/${targetPkgs.stdenv.cc.targetPrefix}cc";
+          CGO_CFLAGS = "-O2";
+          CGO_LDFLAGS = "";
+
+          buildPhase = ''
+            export CC="${targetPkgs.stdenv.cc}/bin/${targetPkgs.stdenv.cc.targetPrefix}cc"
+            export CGO_ENABLED=1
+            export GOOS=${finalGoos}
+            export GOARCH=${finalGoarch}
+            make
+          '';
+
+          installPhase = ''
+            mkdir -p $out/bin
+            cp dkm $out/bin/
+          '';
+
+          meta = with pkgs.lib; {
+            description = "Doge Key Manager";
+            homepage = "https://github.com/dogeorg/dkm";
+            license = licenses.mit;
+            maintainers = with maintainers; [ dogecoinfoundation ];
+            platforms = platforms.all;
+          };
         };
 
-        dbxSessionName = "dkm";
-        dbxStartCommand = "make dev";
-      }
-    );
+      crossPkgsFor =
+        buildSystem: targetSystem:
+        if buildSystem == targetSystem then
+          nixpkgsFor.${buildSystem}
+        else if buildSystem == "x86_64-linux" && targetSystem == "aarch64-linux" then
+          nixpkgsFor.${buildSystem}.pkgsCross.aarch64-multiplatform
+        else if buildSystem == "aarch64-linux" && targetSystem == "x86_64-linux" then
+          nixpkgsFor.${buildSystem}.pkgsCross.gnu64
+        else
+          throw "Cross compilation from ${buildSystem} to ${targetSystem} is not supported";
+
+      buildDkmFor =
+        buildSystem: targetSystem:
+        let
+          pkgs = nixpkgsFor.${buildSystem};
+          targetPkgs = crossPkgsFor buildSystem targetSystem;
+        in
+        buildDkm { inherit pkgs targetPkgs; };
+
+      buildDkmMatrix =
+        buildSystem:
+        nixpkgs.lib.genAttrs supportedSystems (
+          targetSystem:
+          if crossPkgsFor buildSystem targetSystem != null then buildDkmFor buildSystem targetSystem else null
+        );
+    in
+    {
+      packages = forAllSystems (
+        system:
+        let
+          pkgs = nixpkgsFor.${system};
+        in
+        {
+          default = buildDkmFor system system;
+          dkm = buildDkmFor system system;
+
+          cross = nixpkgs.lib.filterAttrs (n: v: v != null) (buildDkmMatrix system);
+        }
+      );
+
+      devShells = forAllSystems (
+        system:
+        let
+          pkgs = nixpkgsFor.${system};
+        in
+        {
+          default = pkgs.mkShell {
+            buildInputs = [
+              pkgs.go_1_22
+            ];
+          };
+        }
+      );
+
+      formatter = forAllSystems (system: nixpkgs.legacyPackages.${system}.nixfmt-rfc-style);
+
+      dbxSessionName = "dkm";
+      dbxStartCommand = "make dev";
+    };
 }


### PR DESCRIPTION
This lets us properly cross compile from x86_64-linux to aarch64-linux, hopefully to allow the whole OS to be cross compiled.

```
[nix-shell:~/dkm]$ uname -a
Linux collie 6.6.69 #1-NixOS SMP PREEMPT_DYNAMIC Thu Jan  2 09:32:11 UTC 2025 x86_64 GNU/Linux

[nix-shell:~/dkm]$ nix build .#cross.aarch64-linux --print-out-paths
warning: Git tree '/home/adam/dkm' is dirty
/nix/store/fsnijwilrkh08zpr98wrf4hvgip05v94-dkm-unstable

[nix-shell:~/dkm]$ file /nix/store/fsnijwilrkh08zpr98wrf4hvgip05v94-dkm-unstable/bin/dkm
/nix/store/fsnijwilrkh08zpr98wrf4hvgip05v94-dkm-unstable/bin/dkm: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), dynamically linked, interpreter /nix/store/cv1868kzij6dl9101xlpxwklisc407gk-glibc-aarch64-unknown-linux-gnu-2.40-66/lib/ld-linux-aarch64.so.1, for GNU/Linux 3.10.0, Go BuildID=4mmC7EHgazFtjqhyN8Dn/_lHbM7X9YS5AtzutJgjC/trgtFwMuh2fDw64LRsLm/RvuwVN7aQ4w7_YYjFygb, with debug_info, not stripped
```